### PR TITLE
feat: :passport_control: Sets bearer token for graphiql fetcher

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -224,7 +224,8 @@ const config: Config = {
 
   themes: ["docusaurus-theme-openapi-docs"],
   customFields: {
-    'TARGETED_API_SCHEMA_URL': process.env.TARGETED_API_SCHEMA_URL,
+    'TARGETED_API_SCHEMA_URL': process.env.TARGETED_API_SCHEMA_URL ?? 'https://targeted-api.adgem.com/v1/offers',
+    'TARGETED_API_TOKEN': process.env.TARGETED_API_TOKEN ?? '2|EIsVDEhAFMJUKvIWsmj9BBFUzjaJlwpd3sRlRvLd3c057761',
   },
 };
 

--- a/src/components/graphql-playground.jsx
+++ b/src/components/graphql-playground.jsx
@@ -1,53 +1,43 @@
 import React from 'react';
-import { createGraphiQLFetcher } from "@graphiql/toolkit";
 import { GraphiQL } from 'graphiql';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { explorerPlugin } from '@graphiql/plugin-explorer';
 
 export default function GraphQLPlayGround() {
-  const {siteConfig} = useDocusaurusContext();
-
-  if (!siteConfig.customFields.TARGETED_API_SCHEMA_URL) {
-    return (
-      <div className="alert alert--danger" role="alert">
-        <h4>Configuration Missing</h4>
-        <p>
-          GraphQL Playground requires API configuration. Please set the 
-          TARGETED_API_SCHEMA_URL environment variable.
-        </p>
-      </div>
-    );
-  }
-  
-  const fetcher = createGraphiQLFetcher({
-    url: siteConfig.customFields.TARGETED_API_SCHEMA_URL || '',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    }
-  });
+  const { siteConfig } = useDocusaurusContext();
 
   return (
-    <BrowserOnly>
+    <BrowserOnly fallback={<div>Loading GraphiQL...</div>}>
       {() => {
+        const { createGraphiQLFetcher } = require('@graphiql/toolkit');
+        const { explorerPlugin } = require('@graphiql/plugin-explorer');
         require('graphiql/style.css');
         require('@graphiql/plugin-explorer/style.css');
+
+        const fetcher = createGraphiQLFetcher({
+          url: siteConfig.customFields.TARGETED_API_SCHEMA_URL,
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: `Bearer ${siteConfig.customFields.TARGETED_API_TOKEN}`,
+          },
+        });
+
         const explorer = explorerPlugin();
+
         return (
           <div>
             <div id='graphiql-info' className="alert alert--info margin-bottom--md" role="alert">
               <h4>Using the GraphQL Playground</h4>
               <p>
-                To authenticate your requests, add your API token in the "Headers" tab at the bottom:
+                To use your own API token, add your API token in the "Headers" tab at the bottom:
                 <pre>{'{\n  "Authorization": "Bearer YOUR_TOKEN_HERE" \n}'}</pre>
               </p>
             </div>
-            <GraphiQL 
-              fetcher={fetcher} 
-              plugins={[explorer]} 
-              shouldPersistHeaders={true} 
-              defaultHeaders={'{"Authorization": "Bearer YOUR_TOKEN_HERE"}'} 
+            <GraphiQL
+              fetcher={fetcher}
+              plugins={[explorer]}
+              shouldPersistHeaders={true}
             />
           </div>
         );


### PR DESCRIPTION
Ticket AGPI-

---

### Changes

- Sets bearer token for graphiql fetcher

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The GraphQL Playground now automatically includes an authorization token when making API requests.

- **Refactor**
  - Improved loading experience with a fallback message while the Playground loads.
  - Updated how certain dependencies are loaded for better performance.

- **Style**
  - Minor updates to informational text within the GraphQL Playground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->