### PR TITLE
docs: update API documentation to reflect Cognito authentication

### DIFF
--- a/docs/integrations/targeted-api/authentication.mdx
+++ b/docs/integrations/targeted-api/authentication.mdx
@@ -82,7 +82,7 @@ curl -X POST https://targeted-api.adgem.com/v1/offers \
 
 JWT tokens have a limited lifespan. When your token expires, you will receive a `401 Unauthorized` response. Simply request a new token using the same process described above.
 
-Also consider you can predict token expiration using the JWT payload's `exp` claim. This field indicates the expiration time as a Unix timestamp allowing you to refresh the token proactively before it expires.
+You can also predict token expiration using the JWT payload's `exp` claim. This field indicates the expiration time as a Unix timestamp, allowing you to refresh the token proactively before it expires.
 
 ## Error Handling
 

--- a/docs/integrations/targeted-api/authentication.mdx
+++ b/docs/integrations/targeted-api/authentication.mdx
@@ -35,10 +35,11 @@ You do not need to perform these steps yourself. Contact the AdGem Team if you h
 
 ### Step 1: Obtain Your Credentials
 
-Contact the AdGem Team to receive your `auth_token`. This credential is unique to your application and acts as a long-lived refresh token that you will use to obtain short-lived access tokens.
+Contact the AdGem Team to receive your `auth_token`. This credential is unique to your application and should be stored only in secure server-side systems to obtain short-lived access tokens.
 
 :::caution Credential Security
-Keep your `auth_token` secure. Do not expose it in client-side code or share it publicly. If you believe your token has been compromised, contact the AdGem Team immediately.
+Treat your `auth_token` as a secret. Do not expose it in browser/mobile client code or share it publicly. 
+Call `/v1/users/token` from your backend, and pass only short-lived `access_token` values to clients when needed. If you believe your token has been compromised, contact the AdGem Team immediately.
 :::
 
 ### Step 2: Request a JWT Access Token

--- a/docs/integrations/targeted-api/authentication.mdx
+++ b/docs/integrations/targeted-api/authentication.mdx
@@ -6,52 +6,66 @@ sidebar_position: 2
 
 # Authentication
 
-The Targeted API uses a JWT-based authentication system powered by Amazon Cognito. This guide explains how to obtain and use access tokens to authenticate your requests.
+The Targeted API uses a JWT-based authentication system powered by Amazon Cognito. This guide explains the complete authentication flow, including the prerequisites handled by the AdGem Team and the steps you need to perform to obtain and use access tokens.
 
 ## Overview
 
-To access the Targeted API, you need to:
+The authentication process involves two phases:
 
-1. Obtain a JWT token using your credentials
-2. Include the token in the `Authorization` header of subsequent requests
+1. **Account Setup (performed by AdGem Team):** The AdGem Team registers and confirms your user account, then provides you with an `auth_token` (a long-lived refresh token).
+2. **Token Acquisition (performed by you):** You exchange the `auth_token` for a short-lived JWT `access_token`, which you include in the `Authorization` header of all API requests.
+
+### Prerequisites
+
+Before you can authenticate, the AdGem Team must complete the following internal steps for your account:
+
+1. **User Registration** -- Your user account is registered in the authentication system.
+2. **User Confirmation** -- Your account is confirmed and activated.
+3. **Auth Token Generation** -- A long-lived `auth_token` is generated and shared with you securely.
+
+You do not need to perform these steps yourself. Contact the AdGem Team if you have not received your credentials.
 
 ### Required Credentials
 
-You will need the following four values to authenticate:
-
-| Credential | Description |
-|------------|-------------|
-| `adgem_pub_id` | Your AdGem publisher identifier |
-| `adgem_app_id` | Your AdGem application identifier |
-| `client_id` | Your application's client identifier |
-| `client_secret` | Your application's client secret |
-
-All four values are required to obtain a JWT token.
+| Credential | Description | Provided By |
+|------------|-------------|-------------|
+| `auth_token` | Your long-lived authentication token (refresh token) | AdGem Team |
 
 ## Step-by-Step Guide
 
 ### Step 1: Obtain Your Credentials
 
-Before you can authenticate, you need to obtain your `client_id` and `client_secret` from the AdGem team. These credentials are unique to your application.
+Contact the AdGem Team to receive your `auth_token`. This credential is unique to your application and acts as a long-lived refresh token that you will use to obtain short-lived access tokens.
 
-### Step 2: Request a JWT Token
+:::caution Credential Security
+Keep your `auth_token` secure. Do not expose it in client-side code or share it publicly. If you believe your token has been compromised, contact the AdGem Team immediately.
+:::
 
-Make a POST request to the `/v1/apps/tokens` endpoint with your credentials:
+### Step 2: Request a JWT Access Token
+
+Make a POST request to the `/v1/users/token` endpoint with your `auth_token`:
 
 ```bash
-curl -X POST https://targeted-api.adgem.com/v1/apps/tokens \
+curl -X POST https://targeted-api.adgem.com/v1/users/token \
   -H "Content-Type: application/json" \
   -d '{
-    "adgem_pub_id": 0,
-    "adgem_app_id": 0,
-    "client_id": "your-client-id",
-    "client_secret": "your-client-secret"
+    "auth_token": "<your-auth-token>"
   }'
 ```
 
-See the [Tokens endpoint documentation](./tokens) for more details.
+A successful response returns a `201 Created` status with your access token:
 
-### Step 3: Use the JWT Token
+```json
+{
+  "message": "Authorized",
+  "access_token": "<your-jwt-token>",
+  "expires_in": 3600
+}
+```
+
+See the [Tokens endpoint documentation](./tokens) for full request and response details.
+
+### Step 3: Use the JWT Access Token
 
 Include the JWT token in the `Authorization` header of all subsequent requests:
 
@@ -76,9 +90,11 @@ Also consider you can predict token expiration using the JWT payload's `exp` cla
 |-------------|-------------|
 | `401 Unauthorized` | Invalid or expired token. Request a new token. |
 | `403 Forbidden` | Token is valid but lacks required permissions. |
+| `422 Unprocessable Entity` | Missing required fields in the request body. |
 
 ## Best Practices
 
-- **Store tokens securely**: Never expose your `clientSecret` in client-side code.
-- **Implement token refresh**: Monitor for `401` responses and automatically request new tokens.
+- **Store credentials securely**: Never expose your `auth_token` in client-side code or public repositories.
+- **Implement token refresh**: Monitor for `401` responses and automatically request new access tokens using your `auth_token`.
+- **Proactive refresh**: Use the `expires_in` value or the JWT `exp` claim to refresh tokens before they expire, avoiding interrupted requests.
 - **Use HTTPS**: Always make requests over HTTPS to protect your credentials and tokens.

--- a/docs/integrations/targeted-api/offers-endpoint.mdx
+++ b/docs/integrations/targeted-api/offers-endpoint.mdx
@@ -39,7 +39,7 @@ curl -X POST https://targeted-api.adgem.com/v1/offers \
   -H "Authorization: Bearer <your-jwt-token>" \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetOffers($playerId: String!) { offers(player_id: $playerId) { id name total_payout_usd creatives { description } } }",
+    "query": "query GetOffers($playerId: String!) { offers(player_id: $playerId) { id name total_payout_usd creatives { name description } } }",
     "variables": {
       "playerId": "user-123"
     }
@@ -57,6 +57,7 @@ curl -X POST https://targeted-api.adgem.com/v1/offers \
         "name": "Example Offer",
         "total_payout_usd": 1.50,
         "creatives": {
+          "name": "Example Offer Creative",
           "description": "Complete this offer to earn rewards."
         }
       }
@@ -80,6 +81,12 @@ Returned when the JWT token is missing or invalid.
 #### 403 Forbidden
 
 Returned when the token is valid but lacks the required scopes.
+
+```json
+{
+  "message": "Forbidden operation."
+}
+```
 
 ## Available Queries
 

--- a/docs/integrations/targeted-api/offers-endpoint.mdx
+++ b/docs/integrations/targeted-api/offers-endpoint.mdx
@@ -1,0 +1,93 @@
+---
+id: offers-endpoint
+title: Offers Endpoint
+sidebar_position: 4
+---
+
+# Offers Endpoint
+
+The `/v1/offers` endpoint is the GraphQL entry point for retrieving targeted offers. All GraphQL queries are sent as POST requests to this endpoint.
+
+## Endpoint
+
+```
+POST https://targeted-api.adgem.com/v1/offers
+```
+
+## Request
+
+### Headers
+
+| Header | Value | Required | Description |
+|--------|-------|----------|-------------|
+| `Authorization` | `Bearer <your-jwt-token>` | Yes | JWT access token obtained from the [Tokens endpoint](./tokens) |
+| `Content-Type` | `application/json` | Yes | Request body format |
+
+### Body
+
+The request body must contain a valid GraphQL query in JSON format:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | `string` | Yes | The GraphQL query string |
+| `variables` | `object` | No | Variables referenced in the query |
+
+### Example Request
+
+```bash
+curl -X POST https://targeted-api.adgem.com/v1/offers \
+  -H "Authorization: Bearer <your-jwt-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query GetOffers($playerId: String!) { offers(player_id: $playerId) { id name total_payout_usd creatives { description } } }",
+    "variables": {
+      "playerId": "user-123"
+    }
+  }'
+```
+
+### Example Response (200 OK)
+
+```json
+{
+  "data": {
+    "offers": [
+      {
+        "id": "123456789",
+        "name": "Example Offer",
+        "total_payout_usd": 1.50,
+        "creatives": {
+          "description": "Complete this offer to earn rewards."
+        }
+      }
+    ]
+  }
+}
+```
+
+## Error Responses
+
+#### 401 Unauthorized
+
+Returned when the JWT token is missing or invalid.
+
+```json
+{
+  "message": "Invalid or missing token."
+}
+```
+
+#### 403 Forbidden
+
+Returned when the token is valid but lacks the required scopes.
+
+## Available Queries
+
+- [**offers**](./operations/queries/offers) -- Retrieve all targeted offers for a player
+- [**links**](./operations/queries/links) -- Retrieve tracking links for a player
+
+## See Also
+
+- [Authentication Guide](./authentication) - How to obtain a JWT access token
+- [Tokens Endpoint](./tokens) - Token acquisition endpoint reference
+- [Playground](./targeted-api-playground) - Interactive GraphQL playground to test queries

--- a/docs/integrations/targeted-api/tokens.mdx
+++ b/docs/integrations/targeted-api/tokens.mdx
@@ -6,12 +6,12 @@ sidebar_position: 3
 
 # Tokens
 
-The `/v1/apps/tokens` endpoint allows you to obtain a JWT access token using your application credentials.
+The `/v1/users/token` endpoint allows you to obtain a JWT access token by exchanging your `auth_token` for a short-lived access token.
 
 ## Endpoint
 
 ```
-POST https://targeted-api.adgem.com/v1/apps/tokens
+POST https://targeted-api.adgem.com/v1/users/token
 ```
 
 ## Request
@@ -26,65 +26,70 @@ POST https://targeted-api.adgem.com/v1/apps/tokens
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `adgem_pub_id` | `integer` | Yes | Your AdGem publisher identifier |
-| `adgem_app_id` | `integer` | Yes | Your AdGem application identifier |
-| `client_id` | `string` | Yes | Your application's client identifier |
-| `client_secret` | `string` | Yes | Your application's client secret |
+| `auth_token` | `string` | Yes | Your long-lived authentication token provided by the AdGem Team |
 
 ### Example Request
 
 ```bash
-curl -X POST https://targeted-api.adgem.com/v1/apps/tokens \
+curl -X POST https://targeted-api.adgem.com/v1/users/token \
   -H "Content-Type: application/json" \
   -d '{
-    "adgem_pub_id": 0,
-    "adgem_app_id": 0,
-    "client_id": "your-client-id",
-    "client_secret": "your-client-secret"
+    "auth_token": "<your-auth-token>"
   }'
 ```
 
 ## Response
 
-### Success Response (200 OK)
+### Success Response (201 Created)
 
 When the credentials are valid, the API returns a JWT access token:
 
 ```json
 {
+  "message": "Authorized",
   "access_token": "<your-jwt-token>",
-  "token_type": "Bearer",
   "expires_in": 3600
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `message` | `string` | Authorization status message |
 | `access_token` | `string` | The JWT token to use in subsequent requests |
-| `token_type` | `string` | The type of token (always `Bearer`) |
 | `expires_in` | `integer` | Token validity duration in seconds |
 
 ### Error Responses
 
 #### 401 Unauthorized
 
-Returned when the provided credentials are invalid.
+Returned when the provided `auth_token` is invalid or expired.
 
 ```json
 {
-  "error": "invalid_client",
-  "error_description": "Invalid client credentials"
+  "message": "Authentication failed. Please check your credentials and try again."
 }
 ```
 
-#### 500 Internal Server Error
+#### 403 Forbidden
 
-Returned when an unexpected error occurs during token generation.
+Returned when the authenticated user lacks the required permissions.
 
 ```json
 {
-  "error": "server_error",
-  "error_description": "An unexpected error occurred"
+  "message": "Forbidden."
+}
+```
+
+#### 422 Unprocessable Entity
+
+Returned when required fields are missing from the request body.
+
+```json
+{
+  "message": "The auth_token field is required.",
+  "errors": {
+    "auth_token": ["The auth_token field is required."]
+  }
 }
 ```
 
@@ -94,7 +99,7 @@ Once you have obtained the access token, include it in the `Authorization` heade
 
 ```bash
 curl -X POST https://targeted-api.adgem.com/v1/offers \
-  -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." \
+  -H "Authorization: Bearer <your-jwt-token>" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "{ offers(player_id: \"user123\") { id name total_payout_usd } }"
@@ -103,10 +108,10 @@ curl -X POST https://targeted-api.adgem.com/v1/offers \
 
 ## Token Lifecycle
 
-1. **Request** - Call `/v1/apps/tokens` with your credentials
-2. **Receive** - Store the `access_token` from the response
-3. **Use** - Include the token in the `Authorization` header
-4. **Refresh** - When you receive a `401` response, request a new token
+1. **Request** -- Call `/v1/users/token` with your `auth_token`
+2. **Receive** -- Store the `access_token` from the response
+3. **Use** -- Include the token in the `Authorization` header of all API requests
+4. **Refresh** -- When the token expires or you receive a `401` response, request a new token using the same `auth_token`
 
 ## See Also
 


### PR DESCRIPTION
Ticket AGPI-1612

---

### Changes

- Rewrite `authentication.mdx` with two-phase flow: internal AdGem Team setup (register, confirm, auth_token generation) and client-side token acquisition using `auth_token`
- Update `tokens.mdx` endpoint from `/v1/apps/tokens` to `/v1/users/token`, replace `client_id`/`client_secret` params with `auth_token` as sole credential, update response format to `201 Created` with new fields, and add `403`/`422` error responses
- Add `offers-endpoint.mdx` documenting the GraphQL endpoint `POST /v1/offers` with required headers, request/response examples (including creatives `name` field), available queries, and error handling with `401`/`403` response bodies
- Improve wording for token expiration note in authentication guide
- Strengthen `auth_token` security guidance: clarify server-side only storage, recommend calling `/v1/users/token` from backend and passing only short-lived `access_token` to clients

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>