### PR TITLE
docs(plans): recover June 30 planning docs (decision record, critical-path, content/redirect/platform) [PUB-191]

### DIFF
--- a/docs/plans/2026-06-16-playground-auth-proposal.md
+++ b/docs/plans/2026-06-16-playground-auth-proposal.md
@@ -61,4 +61,31 @@ We want live, interactive playgrounds in the **public** docs so developers can e
 
 **Build-time synergy:** the Documentation Prism app's token can also drive `graphql-to-doc` schema introspection, so standing up the test app + token mechanism unblocks both the generated Prism reference and the playground.
 
-**Sequencing:** MVP = proxy + Documentation apps (frictionless, test data). Follow-up = BYO-token advanced mode. The Prism *reference* (schema + conceptual pages) can proceed independently of the playground.
+**Sequencing — UPDATED 2026-06-18 (timeline-driven):** **BYO (paste access token) ships first as the MVP; the proxy + Documentation apps is the fast-follow default.** (Reversed from the original "proxy MVP" because of the June 30 target — see Part 3.) The Prism *reference* (schema + conceptual pages) proceeds independently of the playground.
+
+---
+
+## Part 3 — BYO vs. Proxy decision record (2026-06-18)
+
+Two approaches were compared in depth. BYO has two sub-variants: paste the **access** token (pub mints out-of-band) vs. paste a **refresh** token and let the playground mint (the "smooth" variant).
+
+### Configuration complexity
+- **BYO (paste access token):** lowest. Playground UI already exists (`graphql-playground.jsx` headers panel; OpenAPI theme auth field). No CORS change (offers endpoints are already `*`); **no token-endpoint CORS** (browser never calls it). No infra. ≈ an auth guide.
+- **BYO (mint from refresh token):** + CORS on the shared `cognito-token` endpoint in **both** services (app-level `config/cors.php`, scoped to docs origin) + refresh token in the browser. A sensitive change.
+- **Proxy + test apps:** highest. Lambda (Function URL) + Secrets Manager + IAM via **CDK in the docs repo** (first IaC in the docs AWS account → platform sign-off + CI deploy creds); a **Documentation publisher + 2 apps** whitelisted + seeded with sample offers; rotate the refresh token; rate-limit the public endpoint. **No CORS changes anywhere.**
+
+### End-user friction
+- **BYO (access token):** high — obtain refresh token → exchange → copy → paste → re-mint ~hourly.
+- **BYO (refresh token):** medium — paste a refresh token once; longer-lived secret in the browser.
+- **Proxy:** none — click and run; no token/login/expiry.
+
+### Assumptions before the user sees offers
+- **BYO (either):** the user is an existing pub with a refresh token; their app is whitelisted/active; offers exist for it; exchange+paste done and token unexpired. → Prospects / evaluators / new pubs likely see **nothing**.
+- **Proxy:** Documentation apps exist + whitelisted + seeded (one-time, owned by us); proxy up + token valid. → **Any** visitor sees consistent demo offers immediately; no assumptions about the user.
+
+### Net
+- **Proxy** is the better *default* for a frictionless, anyone-can-try-it experience aligned with the docs' eval/onboarding audience — the deciding factors being the assumptions row (BYO shows nothing to the audience docs court) and that "frictionless BYO" collapses into a worse-security proxy (token-endpoint CORS + refresh-token-in-browser).
+- **BYO** is far cheaper, has no platform/data dependencies, and is fine if the audience is existing integrators.
+
+### Decision (timeline-driven)
+With a **June 30** "usable" target (~12 days), **ship BYO (access token) first** — it has **no external dependencies** (no platform IaC approval, deploy creds, or Documentation-apps provisioning) and ~no build. The **proxy default is the fast-follow.** BYO is not throwaway — it becomes the documented "advanced: query your own app" mode. Rationale: the proxy's risk to the date isn't the code, it's the cross-team/infra dependencies; and the playground is not the timeline's long pole (content + hosting are).

--- a/docs/plans/2026-06-18-content-status.md
+++ b/docs/plans/2026-06-18-content-status.md
@@ -1,0 +1,37 @@
+# Content status — migrate vs. author-fresh vs. gap (for June 30)
+
+**Date:** 2026-06-18 · Derived from the WS2 remap table (`2026-06-09-ws2-remap-table.md`).
+**Purpose:** tell the team exactly which new-architecture pages **already have source content to migrate** vs. which are **net-new (will lack content unless authored)** vs. **gaps (need a decision first)**. The **✍️ Author-fresh** and **❓ Gap** rows are the work to hand out.
+
+Legend: ✅ **Migrate** (source exists on `main@653b3f3`, just re-home + Prism-rename) · ✍️ **Author-fresh** (no old source) · ❓ **Gap** (needs a decision, then content).
+
+## Get Started
+- ✅ index, welcome (`essentials-overview`), quickstart (`app-property-setup` + `preflight-checks`)
+- ✍️ **core-concepts** (partly from old `offers/*`), **decide**
+
+## Integrate
+- ✅ pre-built/web-offerwall, ios-sdk, android-sdk, unity-sdk (SDK index pages); reward-mechanism/postbacks-v3 + postbacks-v2 (from `webhooks/postback-options` + `offer-api-postback-setup`)
+- ✍️ **overview**, **offer-delivery/index**, **pre-built/index**, **partner-built/index**, **partner-built/prism** (integration narrative), **partner-built/offer-api** (narrative), **reward-mechanism/index**, **reward-mechanism/client-polling** (new — document the SDK polling mechanism), **reward-mechanism/third-party**
+
+## Configure
+- ✅ index, customization (`configuration/offer-wall-customization` + `web-offerwall/customization`), promotions, webhooks (`offer-event-webhooks` + `suspended-player-webhooks`)
+- ✍️ **security**, **sandbox**
+
+## Reference
+- **Offer API (REST):** generated operation + schema pages ✅ done. Conceptual pages ✍️ **overview, authentication, pagination, errors, versioning** (net-new — no old source)
+- **Prism (GraphQL):** schema pages = **generated** (needs the Cognito token). ✅ authentication, tokens, faq (migrate from old `targeted-api`). ✍️ **overview, errors, versioning, recipes**
+- **Reporting API:** ✅ overview (`api-reference/index`). ✍️ **authentication, errors**
+- ✍️ **webhook-events**, **errors** (top-level)
+
+## Resources
+- ✅ index, glossary (`terms-glossary`), branding-assets, player-support-overview (bridge → link out)
+- ✍️ **changelog** (aggregate), **migrations/overview**, **migrations/static-api-to-offer-api**, **migrations/postback-v2-to-v3**
+- ❓ **developer-support**, **product-roadmap**, **support-urls** (keep / externalize / drop — decision then content)
+
+## Gaps needing a decision before content (from the remap table)
+- ❓ **Payments / monetization** — no home in the IA yet (old `monetization/*`: payment-guide, payment-setup). Needs a surface decision (Configure? Resources?).
+- ❓ Per-SDK changelog/example-app/optional-parameters pages (subpages vs. merge).
+- ❓ Prism FAQ home (folded into recipes vs. its own page) — *resolved: own page (`faq`)*.
+
+## Summary for the team
+**Pages that will lack content unless authored = every ✍️ and ❓ above.** The ✅ rows have existing copy to migrate (lower effort). Suggest splitting the ✍️ list by surface across the team and resolving the ❓ gaps first (esp. payments).

--- a/docs/plans/2026-06-18-june30-launch-critical-path.md
+++ b/docs/plans/2026-06-18-june30-launch-critical-path.md
@@ -1,0 +1,51 @@
+# June 30 Launch — Critical Path & MVP Cut Line
+
+**Date:** 2026-06-18 · **Target:** "usable" docs by **June 30** (~9 working days) · **Owner:** Micah
+
+## Honest framing
+The playground (BYO vs proxy) is **not** the long pole. The date is won or lost on **content (WS2)** and **hosting + domain (WS6/WS7)**. Plan accordingly: keep the playground cheap (BYO), and front-load the things with the longest lead times and external owners.
+
+## MVP definition — what "usable by June 30" means
+**IN (MVP):**
+- Five-surface IA, navigable (done).
+- **Offer API (REST) reference** (done, PR #44).
+- **Prism (GraphQL) reference** — *if* a Cognito token lands in time (generate + wire per the approved design).
+- **Priority content** migrated: Get Started (all), Integrate primary paths (Web Offerwall, Prism, Offer API, Postbacks v3), Configure essentials, the Reference conceptual pages, Resources essentials. Cognito-only auth.
+- **BYO playground** (paste access token) for Prism + the REST "try-it."
+- **Hosted** — Amplify + `docs.adgem.com` preferred; **fallback = GH Pages / Amplify default domain** if domain/DNS slip.
+- Build passes + one Playwright visual pass.
+
+**FAST-FOLLOW (post-June 30):**
+- **Proxy + Documentation-apps playground** (the frictionless default).
+- **Algolia search** (needs the live domain to crawl).
+- **Full content depth** on remaining/lower-priority pages + the deferred gap pages (payments, etc.).
+- **Redirects** (full map) + `docs.adgem.com` **cutover** if it slips.
+- **Component-library formal lock** with Iliana (WS4) + content polish.
+- offer-api → docs **automated spec sync** + the **AI PR-check** guardrail.
+
+## Parallel tracks
+| Track | Work | Owner | Notes / dependency |
+|---|---|---|---|
+| **A — Content (long pole)** | Migrate priority content from `origin/main@653b3f3` into the surfaces; Prism naming; cross-links | Docs (Micah + team) | Start **now**; needs the 6 gap decisions (esp. payments home) |
+| **B — Hosting + domain** | Amplify app + `amplify.yml` + env (`baseUrl=/`); `docs.adgem.com` DNS + ACM cert | Platform/Ron; DNS owner (Iliana/WP Engine) | **Longest external lead — start now**; fallback to GH Pages |
+| **C — Prism reference** | One-time Cognito access token → `graphql-to-doc` → wire sidebar (design done) | You (token) + Micah | Blocked on a **one-time token**; SDL fallback is noisy, avoid |
+| **D — Playground (BYO)** | Paste-access-token mode + auth guide; REST try-it | Micah | Cheap, no external deps; offers endpoints already CORS-`*` |
+| **E — Validation/launch** | Link check, visual QA, analytics, go-live | Micah | End of window; gates "usable" |
+
+## Critical path (ordered)
+1. **Now:** kick off the external dependencies (Track B hosting+DNS, Track C token, content gap decisions) — these have the longest lead and gate everything downstream.
+2. **Days 1–6:** Track A content (bulk) in parallel with B (hosting stand-up) and C (Prism generate+wire) and D (BYO playground).
+3. **Days 6–8:** content finishing + cross-links; hosting live (Amplify or GH Pages fallback); Prism wired; playground in.
+4. **Days 8–9:** Track E validation (build, visual QA), analytics, go-live on the available host.
+
+## Risks & mitigations
+- **Domain/DNS lead time** (could push `docs.adgem.com` past June 30) → **launch on GH Pages / Amplify default domain; cut over later.** Don't let DNS block the date.
+- **Content volume** (WS2 is large for 9 days) → **prioritize; ship "usable, not complete."** Depth on lower-priority pages is fast-follow.
+- **Prism token slips** → ship **Offer API complete + Prism pages as "coming soon"/placeholders**; add Prism when the token lands.
+- **Redirects** → only MVP-critical **if a live production docs site is being replaced** (old URLs with traffic/SEO). Otherwise fast-follow. *(See open question.)*
+
+## Open questions that decide the date
+1. **Is there a live production docs site whose URLs need redirect protection at launch?** (Determines whether WS8 is MVP or fast-follow.)
+2. **Who owns `docs.adgem.com` DNS, and can they start now?** (Longest pole — if it can't start today, plan the GH-Pages-fallback launch.)
+3. **Can you mint a one-time Cognito access token for Prism generation now?** (Decides whether Prism is in the MVP.)
+4. **Priority order of content/surfaces** for the MVP cut — which pages are must-have vs. fast-follow?

--- a/docs/plans/2026-06-18-june30-launch-critical-path.md
+++ b/docs/plans/2026-06-18-june30-launch-critical-path.md
@@ -10,7 +10,8 @@ The playground (BYO vs proxy) is **not** the long pole. The date is won or lost 
 - Five-surface IA, navigable (done).
 - **Offer API (REST) reference** (done, PR #44).
 - **Prism (GraphQL) reference** — *if* a Cognito token lands in time (generate + wire per the approved design).
-- **Priority content** migrated: Get Started (all), Integrate primary paths (Web Offerwall, Prism, Offer API, Postbacks v3), Configure essentials, the Reference conceptual pages, Resources essentials. Cognito-only auth.
+- **Priority content** migrated: Get Started (all), Integrate primary paths (Web Offerwall, Prism, Offer API, Postbacks v3), Configure essentials, Resources essentials. Cognito-only auth.
+- **Reference conceptual pages** (Offer API + Prism overview/auth/errors/versioning, etc.): **author-fresh** — these have no old source (see content-status), so they're written, not migrated.
 - **BYO playground** (paste access token) for Prism + the REST "try-it."
 - **Hosted** — Amplify + `docs.adgem.com` preferred; **fallback = GH Pages / Amplify default domain** if domain/DNS slip.
 - Build passes + one Playwright visual pass.

--- a/docs/plans/2026-06-18-platform-tasks.md
+++ b/docs/plans/2026-06-18-platform-tasks.md
@@ -17,7 +17,7 @@ Note: confirm the **docs AWS account + region** with Ron (recorded outside this 
 - [ ] **No `graphql-to-doc` at build, no Cognito token needed in Amplify** — the Prism reference is generated commit-time and committed.
 
 **Env vars**
-- [ ] `DOCUSAURUS_BASE_URL=/` — Amplify serves at root (differs from GH Pages' `/adgem-integrations-documentation/` subpath; this is also the fix for the broken-on-GH-Pages asset paths).
+- [ ] `DOCUSAURUS_BASE_URL=/` — **for Amplify only** (Amplify, including its default domain, serves at root; this also fixes the broken-on-GH-Pages asset paths). **Per-host base path:** the **GH Pages fallback keeps its existing subpath base-url** (`/adgem-integrations-documentation/`, the repo default) — do **not** set `/` there.
 - [ ] `DOCUSAURUS_URL` = the live origin (Amplify default domain first, then `https://docs.adgem.com`).
 - [ ] `PRISM_SCHEMA_URL` = `https://targeted-api.adgem.com/v1/offers` (non-secret; exposed to the client playground). **No `PRISM_ACCESS_TOKEN` needed in Amplify.**
 
@@ -26,7 +26,7 @@ Note: confirm the **docs AWS account + region** with Ron (recorded outside this 
 - [ ] Add `docs.adgem.com` as a custom domain in Amplify; create the DNS record(s) (CNAME/ANAME) it requires.
 - [ ] Provision/verify the TLS cert (Amplify-managed ACM).
 - [ ] Once live: set `DOCUSAURUS_URL=https://docs.adgem.com`; confirm canonical URLs + sitemap.
-- **Fallback if DNS/cert slips past June 30:** launch on the Amplify default domain (or keep GH Pages) and cut over to `docs.adgem.com` as a fast-follow — don't let DNS block the date.
+- **Fallback if DNS/cert slips past June 30:** launch on the **Amplify default domain** (root, `BASE_URL=/`) — or **keep GH Pages** (uses its existing subpath base-url, *not* `/`) — and cut over to `docs.adgem.com` as a fast-follow. Don't let DNS block the date.
 
 **Cutover**
 - [ ] After the domain is live and verified, retire GH Pages + its PR-preview workflow.

--- a/docs/plans/2026-06-18-platform-tasks.md
+++ b/docs/plans/2026-06-18-platform-tasks.md
@@ -1,0 +1,54 @@
+# Platform tasks — docs hosting/domain (now) + playground proxy IaC (fast-follow)
+
+**Date:** 2026-06-18 · For: platform team. Two sections — **Section A is needed for the June 30 launch**; **Section B is the fast-follow** (prep your side so we can drop in the Lambda without waiting).
+
+Note: confirm the **docs AWS account + region** with Ron (recorded outside this public repo).
+
+---
+
+## Section A — Hosting + domain (needed for June 30)
+
+**Amplify app**
+- [ ] Create an Amplify app connected to this repo (`adgem-integrations-documentation`), tracking `main`, in the docs AWS account/region.
+- [ ] Enable **PR previews** (we'll then retire the existing GH Pages `pr-preview/pr-{n}` workflow after cutover).
+
+**Build config** (`amplify.yml` — we can add it; values for your awareness)
+- [ ] Build: `npm ci` → `npm run gen-api-docs` (Offer API; generates from the local `examples/offer.yaml`, **no token/network needed**) → `npm run build`. Artifacts: `build/`.
+- [ ] **No `graphql-to-doc` at build, no Cognito token needed in Amplify** — the Prism reference is generated commit-time and committed.
+
+**Env vars**
+- [ ] `DOCUSAURUS_BASE_URL=/` — Amplify serves at root (differs from GH Pages' `/adgem-integrations-documentation/` subpath; this is also the fix for the broken-on-GH-Pages asset paths).
+- [ ] `DOCUSAURUS_URL` = the live origin (Amplify default domain first, then `https://docs.adgem.com`).
+- [ ] `PRISM_SCHEMA_URL` = `https://targeted-api.adgem.com/v1/offers` (non-secret; exposed to the client playground). **No `PRISM_ACCESS_TOKEN` needed in Amplify.**
+
+**Custom domain `docs.adgem.com`** (longest lead — start ASAP)
+- [ ] Confirm who controls `docs.adgem.com` DNS (platform? Iliana/WP Engine?) and that they can act now.
+- [ ] Add `docs.adgem.com` as a custom domain in Amplify; create the DNS record(s) (CNAME/ANAME) it requires.
+- [ ] Provision/verify the TLS cert (Amplify-managed ACM).
+- [ ] Once live: set `DOCUSAURUS_URL=https://docs.adgem.com`; confirm canonical URLs + sitemap.
+- **Fallback if DNS/cert slips past June 30:** launch on the Amplify default domain (or keep GH Pages) and cut over to `docs.adgem.com` as a fast-follow — don't let DNS block the date.
+
+**Cutover**
+- [ ] After the domain is live and verified, retire GH Pages + its PR-preview workflow.
+
+---
+
+## Section B — Playground proxy + test apps (fast-follow; prep now)
+
+The frictionless playground default needs a thin **forwarding Lambda** (`browser → Lambda → production Prism/Offer API`, auth injected server-side) authenticating as a dedicated **"Documentation" publisher's test apps**. We (docs) will build the Lambda via **CDK in the docs repo**; the items below are the platform/data side so it's ready.
+
+**Platform / infra**
+- [ ] Confirm the AWS account/region for the proxy (same docs account is fine).
+- [ ] **Bootstrap CDK** in that account (`cdk bootstrap`) — this is the **first IaC in the account**; agree the approach/permissions.
+- [ ] IAM: a **deploy role** for the docs CI to deploy the CDK stack; the **Lambda execution role** (read the Secrets Manager secret + outbound HTTPS).
+- [ ] **Secrets Manager**: create a secret to hold the Documentation app's **Cognito refresh token**; define a rotation policy.
+- [ ] **Rate-limiting / WAF** on the public Lambda Function URL (it's a public, forwarding endpoint).
+- [ ] **Cognito**: confirm the Documentation app's client can perform the refresh→access exchange server-side (the proxy will mint short-lived access tokens), and the token endpoint/client config to use.
+
+**Data / product**
+- [ ] Create a **"Documentation" publisher** (team/role email) with **two apps** — one Offer API (untargeted) integration, one Prism (targeted) integration.
+- [ ] **Whitelist** both apps for offers and **seed a small set of benign sample campaigns** assigned to both (so the two playgrounds show consistent demo data). `app_id` is non-secret (it appears in click URLs) — a recognizable id is a nice-to-have, not required.
+- [ ] **Mint the Documentation app's refresh token** and store it in the Secrets Manager secret above.
+
+**Docs (us)**
+- [ ] Build the CDK forwarding-proxy Lambda (GraphQL→Prism, REST→Offer API routes) and wire the playground to it; keep BYO as the advanced mode.

--- a/docs/plans/2026-06-18-redirect-map.md
+++ b/docs/plans/2026-06-18-redirect-map.md
@@ -1,0 +1,45 @@
+# Redirect map (old → new) + cleanliness assessment
+
+**Date:** 2026-06-18 · Derived from the WS2 remap table. **Purpose:** map current production URLs to the v2 IA so we can assess how cleanly it maps (and where it won't) before committing to redirects (WS8).
+
+**Two global changes apply to every URL:**
+- Base path: GH Pages `/adgem-integrations-documentation/...` → (Amplify) root `/...`.
+- `trailingSlash: false` — keep consistent between Docusaurus client redirects and any host-level (Amplify) rules.
+
+Cleanliness: **clean** = 1:1 · **split** = one old page → multiple new (pick a primary target) · **external** = link out · **no target** = unresolved gap.
+
+| Old URL (current prod) | New target | Clean? |
+|---|---|---|
+| `/docs/getting-started` | `/docs/get-started` | clean |
+| `/docs/getting-started/essentials-overview` | `/docs/get-started/welcome` | clean |
+| `/docs/getting-started/app-property-setup` | `/docs/get-started/quickstart` | clean |
+| `/docs/getting-started/preflight-checks` | `/docs/get-started/quickstart` | clean |
+| `/docs/integrations/web-offerwall` | `/docs/integrate/offer-delivery/pre-built/web-offerwall` | clean |
+| `/docs/integrations/{ios,android,unity}-sdk` | `/docs/integrate/offer-delivery/pre-built/{ios,android,unity}-sdk` | clean |
+| `/docs/integrations/web-offerwall/customization` | `/docs/configure/customization` (+ best-practices → web-offerwall page) | split |
+| `/docs/integrations/offer-api/*` (OpenAPI) | `/docs/reference/offer-api/*` | clean (finalize per-page slugs) |
+| `/docs/integrations/targeted-api/*` (GraphQL) | `/docs/reference/prism/*` | clean (finalize after Prism gen) |
+| `/docs/webhooks` | `/docs/integrate/reward-mechanism` (+ `/docs/configure/webhooks`) | split |
+| `/docs/webhooks/postback-options`, `/offer-api-postback-setup` | `/docs/integrate/reward-mechanism/postbacks-v3` | clean |
+| `/docs/webhooks/offer-event-webhooks`, `/suspended-player-webhooks` | `/docs/configure/webhooks` (or `/docs/reference/webhook-events`) | split |
+| `/docs/configuration` | `/docs/configure` | clean |
+| `/docs/configuration/offer-wall-customization` | `/docs/configure/customization` | clean |
+| `/docs/configuration/offer-wall-promotions` | `/docs/configure/promotions` | clean |
+| `/docs/monetization`, `/monetization/payment-*` | **(payments has no v2 home yet)** | **no target** |
+| `/docs/offers` | `/docs/get-started/core-concepts` | split |
+| `/docs/offers/multi-reward-offers`, `/completion-difficulty-scale` | `/docs/get-started/core-concepts` (or Resources/Reference) | split |
+| `/docs/api-reference` | `/docs/reference/reporting-api/overview` | clean |
+| `/docs/resources` (+ glossary, branding-assets) | `/docs/resources/*` | clean |
+| `/docs/resources/developer-support`, `/product-roadmap`, `/support-urls` | **(keep/externalize/drop undecided)** | **no target** |
+| `/docs/resources/service-status` | `https://status.adgem.com` | external |
+| `/docs/legal/privacy-policy` | `https://adgem.com/privacy-policy/` | external |
+| `/docs/legal/terms-and-conditions` | `https://adgem.com/terms-and-conditions/` | external |
+| `/docs/legal/sdk-license-agreement` | **(no external URL found)** | **no target** |
+| `/docs/legal`, `/docs/legal/index` | `https://adgem.com/` (no `/legal` index exists) | external |
+
+## How clean is it?
+- **Most surface moves are clean 1:1** (getting-started, configuration, integrations SDKs/APIs, api-reference, resources).
+- **A handful are "split"** — one old page fans out to two v2 homes (webhooks → Integrate + Configure; offers → core-concepts; web-offerwall customization). For redirects, pick the **primary** target per old URL.
+- **The genuinely messy / unresolved are the gaps:** `monetization/*` (no payments home), the Resources extras (developer-support/product-roadmap/support-urls), and `legal/sdk-license-agreement` — these can't be mapped cleanly until the content gaps (see content-status doc) are decided.
+
+**Verdict:** ~80% maps cleanly; the rest is blocked on the same gap decisions as content. So the redirect map is mostly mechanical *once the gaps are resolved*. Mechanism (Docusaurus client redirects vs. Amplify 301s) is a WS8/hosting decision — see the platform handoff.


### PR DESCRIPTION
Planning docs that were committed locally *after* PR #44 merged and never pushed, so they're missing from `main`. Recovering them (build-excluded `docs/plans/`, no site impact):

- `2026-06-16-playground-auth-proposal.md` — adds **Part 3: BYO-vs-proxy decision record** (BYO MVP first, proxy fast-follow; timeline-driven).
- `2026-06-18-june30-launch-critical-path.md` — June 30 critical path + MVP cut line.
- `2026-06-18-content-status.md` — which v2 pages migrate vs. need fresh authoring vs. are gaps (team handout).
- `2026-06-18-redirect-map.md` — old→new URL map + cleanliness assessment.
- `2026-06-18-platform-tasks.md` — hosting+domain (June 30) and proxy/test-apps IaC (fast-follow) handoffs.

Safe to merge whenever — these are reference/planning only. Getting them onto `main` so `content-status` (wider team) and `platform-tasks` (platform) are shareable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated playground authentication design proposal to make “BYO (paste access token)” the MVP, with proxy-based options as a fast follow.
  * Added a content status/checklist plan to categorize new-architecture documentation work.
  * Added a June 30 launch critical path plan defining MVP scope and validation gates.
  * Added a platform task outline for docs hosting and the playground proxy setup.
  * Added an old-to-new URL redirect mapping guide, including transition rules and identified gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->