### PR TITLE
docs: Get Started narratives — Decide your path + Core concepts (PUB-191)

### DIFF
--- a/docs/get-started/core-concepts.md
+++ b/docs/get-started/core-concepts.md
@@ -26,7 +26,7 @@ A single step within an offer. A **single-reward** offer has one goal — comple
 
 ## Completion difficulty
 
-A ranking of how much time and effort an offer takes to complete, from easy to hard (a quick sign-up versus a multi-day gaming milestone). It helps you decide how to surface or prioritize offers. The exact values are documented on the [offer schema](/docs/reference/offer-api/schemas/offer) in the Reference.
+A ranking of how much time and effort an offer takes to complete, from easy to hard (a quick sign-up versus a multi-day gaming milestone). It helps you decide how to surface or prioritize offers. It's returned as the [`completion_difficulty`](/docs/reference/offer-api/schemas/offer) field on each offer.
 
 ## Conversion
 

--- a/docs/get-started/core-concepts.md
+++ b/docs/get-started/core-concepts.md
@@ -1,12 +1,47 @@
 ---
 title: Core Concepts
 sidebar_label: Core Concepts
+description: The shared vocabulary behind every AdGem integration — properties, offers, goals, conversions, postbacks, and players.
 ---
 
 # Core Concepts
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+A quick tour of the terms used across these docs. For a fuller list, see the [Glossary](/docs/resources/glossary).
 
-The shared vocabulary: properties, offers, goals, conversions, postbacks, players.
+## App property
+
+Your app or site registered in the AdGem Dashboard. Each property has a unique **App ID** that identifies it in every API call, offerwall embed, and postback. You create one in the [Quickstart](/docs/get-started/quickstart).
+
+## Player
+
+One of your end users. You identify each player to AdGem with a **player ID** of your choosing (your own user ID works well). You supply it when you load the offerwall or when you call the APIs, and AdGem returns it on postbacks so you know who to reward.
+
+## Offer
+
+A rewarded task from an advertiser — for example, install an app, sign up, reach a level, or make a purchase. A player earns a reward by completing the offer. Each offer carries a unique ID, creative details (name, description, icon), targeting, and payout information.
+
+## Goal
+
+A single step within an offer. A **single-reward** offer has one goal — complete it, earn the reward. A **multi-reward** offer has several goals, each with its own reward, so a player earns cumulatively as they progress. You can tell them apart by the `is_multi_reward` field on the offer.
+
+## Completion difficulty
+
+A ranking of how much time and effort an offer takes to complete, from easy to hard (a quick sign-up versus a multi-day gaming milestone). It helps you decide how to surface or prioritize offers. The exact values are documented on the [offer schema](/docs/reference/offer-api/schemas/offer) in the Reference.
+
+## Conversion
+
+The moment a player completes an offer (or a goal within one) and becomes eligible for a reward. A conversion is what triggers AdGem to notify you.
+
+## Postback
+
+A server-to-server notification AdGem sends to your endpoint when a conversion happens, so you can grant the player their reward. Postbacks are the recommended, tamper-resistant way to deliver rewards — see [Reward Mechanism](/docs/integrate/reward-mechanism/postbacks-v3). (Pre-built SDKs can alternatively surface rewards through an on-device callback.)
+
+## Reward
+
+The in-app currency or value you grant a player for a conversion. AdGem reports the payout for each conversion; you decide how that maps to your own economy.
+
+## How they fit together
+
+A **player** opens offers tied to your **app property**, completes an **offer** (one or more **goals**), which produces a **conversion**. AdGem sends you a **postback**, and you grant the **reward**.
+
+Ready to choose how to deliver offers? See [Decide your path](/docs/get-started/decide).

--- a/docs/get-started/decide.md
+++ b/docs/get-started/decide.md
@@ -1,12 +1,62 @@
 ---
 title: Decide Your Path
 sidebar_label: Decide Your Path
+description: Choose how to deliver AdGem offers — from a ready-made offerwall to a fully custom build.
 ---
 
 # Decide Your Path
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+Every AdGem integration comes down to one question: **how much do you want to build yourself, and how much do you want AdGem to handle?**
 
-Pick your integration combination — an Offer Delivery path and a Reward Mechanism path. Decision matrix included.
+Offer delivery sits on a spectrum. At one end, AdGem gives you a ready-made offerwall and you ship in an afternoon. At the other, we hand you the raw offer catalog and you build the experience and the logic. Prism sits in the middle: our personalized offers, your UI.
+
+```text
+   Consume more  ◄──────────────────────────────────►  Build more
+   Web Offerwall / SDKs        Prism            Offer API
+   we build the UI          our offers,        raw catalog,
+                            your UI            your UI + logic
+```
+
+## Two questions
+
+**1. Do you want to use AdGem's ready-made offerwall, or build your own UI?**
+
+- **Use our offerwall** → a [pre-built option](/docs/integrate/offer-delivery/pre-built). AdGem owns the UI and the offer presentation; you embed it and pass us a player ID. This is the fastest path and the right fit for most publishers.
+- **Build your own UI** → a [partner-built option](/docs/integrate/offer-delivery/partner-built). You own the front end; AdGem hands you the offers. Continue to question 2.
+
+**2. (Building your own UI) Do you want AdGem's personalization, or full control of the logic?**
+
+- **Keep your UI and gain our personalization** → **[Prism](/docs/integrate/offer-delivery/partner-built/prism)** (recommended). Prism returns a sorted, suppressed, geo- and device-filtered list of offers. You still own the UI, so you keep final control over how offers are presented — the personalization is an input, not a takeover.
+- **Build your own ranking and logic** → **[Offer API](/docs/integrate/offer-delivery/partner-built/offer-api)**. You get the raw offer catalog and build everything on top of it. Best when you need total control, have your own ranking system, or have a hard requirement for raw data access.
+
+## Compare the options
+
+| | Pre-built (Web Offerwall / SDK) | Prism | Offer API |
+|---|---|---|---|
+| In a line | Our ready-made offerwall | Our personalized offers, your UI | Raw catalog, your UI and logic |
+| You build | Little to nothing | Your UI | Your UI and ranking |
+| UI owner | AdGem | You | You |
+| Personalization | Built in | Built in | You build it |
+| Platform | Web, plus iOS / Android / Unity | Any | Any |
+| Engineering lift | Lowest | Medium | Highest |
+| Time to launch | Fastest | Medium | Slowest |
+| Best for | Most publishers | A custom UI with our personalization | Total control, your own ranking, or raw-data needs |
+
+## What else to weigh
+
+- **Platform** — for the ready-made offerwall, choose the [Web Offerwall](/docs/integrate/offer-delivery/pre-built/web-offerwall) for web and in-app web views, or a native [iOS](/docs/integrate/offer-delivery/pre-built/ios-sdk), [Android](/docs/integrate/offer-delivery/pre-built/android-sdk), or [Unity](/docs/integrate/offer-delivery/pre-built/unity-sdk) SDK for native apps. Prism and the Offer API work anywhere.
+- **Engineering capacity** — less to invest favors pre-built; the more you want to build, the further down the spectrum you can go.
+- **Time to revenue** — pre-built is fastest to launch; Prism is in the middle; the Offer API takes the most build time.
+- **Control** — if brand and UX control matter but you don't want to build a ranking engine, Prism is the sweet spot.
+
+You're not locked in. Publishers can move along the spectrum later — taking on more control, or offloading work back to AdGem — as their needs change.
+
+## Then: how rewards flow back
+
+Offer delivery is one axis; the other is how conversions return to you so you can reward players. Most integrations use **[server postbacks](/docs/integrate/reward-mechanism/postbacks-v3)** (recommended). Pre-built SDKs can also deliver rewards through an on-device callback. See [Reward Mechanism](/docs/integrate/reward-mechanism) for the details — you choose it independently of your delivery path.
+
+## Next steps
+
+- Ready to set up? Start with the [Quickstart](/docs/get-started/quickstart).
+- New to the terminology? See [Core concepts](/docs/get-started/core-concepts).
+- Want the full API specs? See the [Reference](/docs/reference).

--- a/docs/get-started/decide.md
+++ b/docs/get-started/decide.md
@@ -8,7 +8,7 @@ description: Choose how to deliver AdGem offers — from a ready-made offerwall 
 
 Every AdGem integration comes down to one question: **how much do you want to build yourself, and how much do you want AdGem to handle?**
 
-Offer delivery sits on a spectrum. At one end, AdGem gives you a ready-made offerwall and you ship in an afternoon. At the other, we hand you the raw offer catalog and you build the experience and the logic. Prism sits in the middle: our personalized offers, your UI.
+Offer delivery sits on a spectrum. At one end, AdGem gives you a ready-made offerwall to embed. At the other, we hand you the raw offer catalog and you build the experience and the logic. Prism sits in the middle: our personalized offers, your UI.
 
 ```text
    Consume more  ◄──────────────────────────────────►  Build more

--- a/docs/get-started/decide.md
+++ b/docs/get-started/decide.md
@@ -10,12 +10,26 @@ Every AdGem integration comes down to one question: **how much do you want to bu
 
 Offer delivery sits on a spectrum. At one end, AdGem gives you a ready-made offerwall to embed. At the other, we hand you the raw offer catalog and you build the experience and the logic. Prism sits in the middle: our personalized offers, your UI.
 
-```text
-   Consume more  ◄──────────────────────────────────►  Build more
-   Web Offerwall / SDKs        Prism            Offer API
-   we build the UI          our offers,        raw catalog,
-                            your UI            your UI + logic
-```
+<div className="delivery-spectrum">
+<div className="delivery-spectrum__track">
+<span>Consume more</span>
+<span>Build more</span>
+</div>
+<div className="delivery-spectrum__tiers">
+<div className="delivery-spectrum__tier">
+<strong>Web Offerwall / SDKs</strong>
+<span>We build the UI. You embed it and pass a player ID.</span>
+</div>
+<div className="delivery-spectrum__tier">
+<strong>Prism</strong>
+<span>Our personalized offers, your UI.</span>
+</div>
+<div className="delivery-spectrum__tier">
+<strong>Offer API</strong>
+<span>The raw catalog. Your UI and logic.</span>
+</div>
+</div>
+</div>
 
 ## Two questions
 

--- a/docs/plans/2026-06-25-integration-narratives-design.md
+++ b/docs/plans/2026-06-25-integration-narratives-design.md
@@ -1,0 +1,53 @@
+# Integration narrative pages — design (PUB-191)
+
+**Date:** 2026-06-25 · **Driver:** Micah · **Status:** approved, drafting
+
+The marketing/product content gaps: 8 net-new narrative/positioning pages. Drafted by docs/eng, then routed to marketing/product for review.
+
+## Framing spine
+
+One axis: **how much do you want to build vs. let AdGem handle?** Presented as a spectrum, **by fit** — platform, control appetite, engineering capacity, time-to-revenue.
+
+```
+Consume ◄──────────────────────────────────────► Build
+Web Offerwall / SDKs   →   Prism   →   Offer API
+(we build the UI)        (our offers,    (raw catalog,
+                          your UI)        your UI + logic)
+```
+
+### Source + firewall
+
+The spine is the publisher-safe distillation of the internal **"Integration Model Selector — Which Model to Pitch"** sheet. That doc is **internal only**. Only the build-vs-consume mental model and the *neutral* comparison axes inform these pages. **Never published:** the internal push order ("lead with Iframe," "SDK to battle-test"), gaps/roadmap (SDK readiness, ANR, app-grouping rebuild, SDK-primary gate, Prism-in-SDK), and commercial strategy ("Prism is the moat," value-capture/stickiness, Offer-API-by-exception/SE-gating, RPC metric, L0–L5 tiers, names/meetings). Also **not** surfaced: the "powered by" plumbing (pre-built runs on Prism, Prism on Offer API) — implementation detail that doesn't help a publisher choose. "Iframe" = the **Web Offerwall** publisher-side; we don't introduce "Iframe" as a separate product name.
+
+## Pages (mixed depth)
+
+**Get Started — substantial (cluster A):**
+
+1. **Decide your path** (`get-started/decide`) — the anchor: build-vs-consume spectrum + decision matrix (below) + routing by platform → control appetite → engineering capacity → time-to-revenue. Links each option to its guide.
+2. **Core concepts** (`get-started/core-concepts`) — vocabulary: properties/apps, offers, multi-reward offers + goals, completion difficulty, conversions, postbacks, players. Grounded in legacy essentials-overview / offers pages.
+
+**Integrate — thin connectors (cluster B):**
+
+3. **Integrate / overview** — two independent axes (Offer Delivery × Reward Mechanism) + one-line build-vs-consume + "not sure? → Decide your path."
+4. **Offer Delivery landing** — pre-built vs partner-built; route to the branches.
+5. **Pre-built landing** — AdGem owns the UI; Web Offerwall (web) + iOS/Android/Unity SDKs (native), by platform fit.
+6. **Partner-built landing** — you own the UI; Prism (recommended) vs Offer API, by fit.
+7. **Prism narrative** — when/why Prism: personalization (sorting, suppression, geo/device) as an input you keep control over — additive, not a takeover; recommended for custom UIs. Links to Reference/Prism.
+8. **Offer API narrative** — when/why Offer API: raw full catalog, you build ranking + UI; fits total-control / own-ranking / raw-data needs. Links to Reference/Offer API.
+
+## Decide-your-path matrix (publisher-safe rows)
+
+| | Pre-built (Web Offerwall / SDK) | Prism | Offer API |
+|---|---|---|---|
+| In a line | Our ready-made offerwall | Our personalized offers, your UI | Raw catalog, your UI + logic |
+| You build | Little to nothing | Your UI | Your UI + ranking |
+| UI owner | AdGem | You | You |
+| Personalization | Built in | Built in | You build |
+| Platform | Web + iOS/Android/Unity | Any | Any |
+| Engineering lift | Lowest | Medium | Highest |
+| Time to launch | Fastest | Medium | Slowest |
+| Best for | Most publishers | Custom UI + our personalization | Total control / own ranking / raw-data needs |
+
+## Sequencing
+
+Two PRs off `main`: **(A)** Get Started (pages 1–2), then **(B)** the six Integrate connectors. Both routed to marketing/product for review.

--- a/docs/plans/2026-06-25-integration-narratives-design.md
+++ b/docs/plans/2026-06-25-integration-narratives-design.md
@@ -8,7 +8,7 @@ The marketing/product content gaps: 8 net-new narrative/positioning pages. Draft
 
 One axis: **how much do you want to build vs. let AdGem handle?** Presented as a spectrum, **by fit** — platform, control appetite, engineering capacity, time-to-revenue.
 
-```
+```text
 Consume ◄──────────────────────────────────────► Build
 Web Offerwall / SDKs   →   Prism   →   Offer API
 (we build the UI)        (our offers,    (raw catalog,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -487,3 +487,59 @@ button,
 .openapi-schema__list-item > div > p {
   margin-bottom: 0.25rem;
 }
+
+/* ============================================
+   Decide your path — delivery spectrum
+   Build-vs-consume visual. Tiers wrap on narrow
+   viewports (flex-wrap), so it's responsive with
+   no media queries.
+   ============================================ */
+
+.delivery-spectrum {
+  margin: 1.5rem 0 2rem;
+}
+
+.delivery-spectrum__track {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 1.25rem;
+  margin-bottom: 1rem;
+  border-radius: 50px;
+  background: linear-gradient(90deg, var(--adgem-secondary-purple), var(--adgem-accent-magenta));
+  color: var(--adgem-white);
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.delivery-spectrum__tiers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.delivery-spectrum__tier {
+  flex: 1 1 200px;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-top: 3px solid var(--adgem-secondary-purple);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+}
+
+.delivery-spectrum__tier strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-family: var(--ifm-heading-font-family);
+  font-size: 1rem;
+}
+
+.delivery-spectrum__tier span {
+  font-size: 0.875rem;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.4;
+}


### PR DESCRIPTION
Cluster A of the marketing/product narrative pages (the gaps doc's net-new content). **For marketing/product review.** Base: `main`.

## New content
- **Get Started › Decide your path** — the decision anchor. Frames offer delivery as a **build-vs-consume spectrum** (Web Offerwall/SDK → Prism → Offer API), a two-question router, a publisher-safe comparison matrix, and weighing factors (platform, engineering capacity, time-to-revenue, control). Prism positioned as recommended for custom UIs ("personalization is an input, not a takeover"); Offer API for total-control/own-ranking/raw-data needs.
- **Get Started › Core concepts** — shared vocabulary (app property, player, offer, goal, multi-reward, completion difficulty, conversion, postback, reward) + a "how they fit together" wrap-up. Grounded in the legacy essentials-overview / offers pages.

## Source + firewall
Distilled from the internal **Integration Model Selector** sheet. Only the publisher-safe mental model and neutral comparison axes are used — **no** internal push order, gaps/roadmap, or commercial strategy, and no "powered by" plumbing. "Iframe" is presented as the **Web Offerwall**. Design recorded in `docs/plans/2026-06-25-integration-narratives-design.md`.

## ⚠️ One thing to confirm
**Completion difficulty scale:** the legacy page says **1–7**, but the API changelog/schema says **1–3**. I described it qualitatively (easy→hard) and pointed to the offer schema rather than assert a range — please confirm the current scale so the schema/reference can state it precisely.

## Notes
- Builds clean (no broken links). Cluster B (the six Integrate connector pages) is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced placeholder onboarding content with a detailed “Core Concepts” guide, including key integration terms and related links.
  * Expanded the “Decide your path” page into a full decision guide with comparison options, guidance factors, and next steps.
  * Added a new planning document outlining the updated integration narrative structure and page roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->