### PR TITLE
docs: Integrate connector pages — cluster B (PUB-191)

### DIFF
--- a/docs/integrate/offer-delivery/index.md
+++ b/docs/integrate/offer-delivery/index.md
@@ -1,12 +1,16 @@
 ---
 title: Offer Delivery
 sidebar_label: Offer Delivery
+description: How players see and start AdGem offers — a ready-made offerwall or a UI you build yourself.
 ---
 
 # Offer Delivery
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+Offer Delivery is how your players see and start AdGem offers. There are two approaches:
 
-How your players see and start AdGem offers. Pick Pre-built for speed; pick Partner-built for control.
+- **[Pre-built](/docs/integrate/offer-delivery/pre-built)** — AdGem provides the offerwall UI. You embed it and pass us a player ID. This is the fastest path and fits most publishers.
+- **[Partner-built](/docs/integrate/offer-delivery/partner-built)** — you build your own UI on our APIs. Choose this when you want control over the offer experience.
+
+The difference is how much you build versus how much AdGem handles. To weigh that trade-off, see **[Decide your path](/docs/get-started/decide)**.
+
+Offer Delivery is independent of your **[Reward Mechanism](/docs/integrate/reward-mechanism)** — choose that separately.

--- a/docs/integrate/offer-delivery/partner-built/index.md
+++ b/docs/integrate/offer-delivery/partner-built/index.md
@@ -1,12 +1,14 @@
 ---
 title: Partner-built (Custom Experience)
 sidebar_label: Partner-built (Custom Experience)
+description: Build your own offer UI on AdGem's APIs — Prism for our personalization, or the Offer API for raw catalog control.
 ---
 
 # Partner-built (Custom Experience)
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+With a partner-built integration, you own the UI and AdGem provides the offers through an API. There are two options, depending on how much of the logic you want to own:
 
-You own the UI; AdGem hands you the offers. Best when you need bespoke UX or deep product integration.
+- **[Prism](/docs/integrate/offer-delivery/partner-built/prism)** (recommended) — a GraphQL API that returns personalized, sorted, filtered offers. You keep your UI and gain our personalization. Best for most custom-UI builds.
+- **[Offer API](/docs/integrate/offer-delivery/partner-built/offer-api)** — a REST API that returns the raw offer catalog. You build the ranking and presentation yourself. Best when you need total control or have your own ranking system.
+
+Both let you build the experience you want; the difference is whether AdGem's personalization powers it or you supply your own. To weigh the trade-off, see **[Decide your path](/docs/get-started/decide)**. For full specifications, see the **[Reference](/docs/reference)**.

--- a/docs/integrate/offer-delivery/partner-built/offer-api.md
+++ b/docs/integrate/offer-delivery/partner-built/offer-api.md
@@ -1,12 +1,25 @@
 ---
 title: Offer API
 sidebar_label: Offer API
+description: When and why to choose the Offer API — AdGem's REST API for the raw offer catalog, ranked and presented by you.
 ---
 
 # Offer API
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+The Offer API is AdGem's REST API for retrieving the raw offer catalog and building your own UI on top of it. You control everything: the ranking, the filtering, and the presentation.
 
-REST surface for retrieving offers and building your own UI.
+## Why the Offer API
+
+The Offer API returns the full set of available offers with rich metadata, and leaves the logic to you. Nothing is pre-ranked or personalized — you decide how offers are ordered and shown. That's the most work of any integration, and the most control.
+
+## When to choose it
+
+- You need **total control** over ranking and presentation.
+- You have your own ranking or personalization system you want to feed with raw catalog data.
+- You have a hard requirement for raw data access (for example, data-residency or compliance needs).
+
+If you want a custom UI but would rather build on AdGem's personalization than your own ranking, [Prism](/docs/integrate/offer-delivery/partner-built/prism) is the recommended option. If you don't need to build a UI, see [Pre-built](/docs/integrate/offer-delivery/pre-built).
+
+## Build with the Offer API
+
+See the **[Offer API reference](/docs/reference/offer-api/overview)** for the endpoint, authentication, pagination, and examples.

--- a/docs/integrate/offer-delivery/partner-built/prism.md
+++ b/docs/integrate/offer-delivery/partner-built/prism.md
@@ -8,7 +8,7 @@ description: When and why to choose Prism — AdGem's GraphQL API that returns p
 
 **Recommended for most custom-UI builds.**
 
-Prism is AdGem's GraphQL API (formerly the "Targeted API") for building your own offer experience. You own the UI; Prism supplies the offers — already personalized.
+Prism is AdGem's GraphQL API for building your own offer experience. You own the UI; Prism supplies the offers — already personalized.
 
 ## Why Prism
 

--- a/docs/integrate/offer-delivery/partner-built/prism.md
+++ b/docs/integrate/offer-delivery/partner-built/prism.md
@@ -1,12 +1,29 @@
 ---
 title: Prism
 sidebar_label: Prism
+description: When and why to choose Prism — AdGem's GraphQL API that returns personalized offers for your own UI.
 ---
 
 # Prism
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+**Recommended for most custom-UI builds.**
 
-`[Recommended]` GraphQL surface (formerly "Targeted API") for building your own offer experience.
+Prism is AdGem's GraphQL API (formerly the "Targeted API") for building your own offer experience. You own the UI; Prism supplies the offers — already personalized.
+
+## Why Prism
+
+Prism returns offers that are sorted, suppressed, and geo- and device-filtered for the player you request them for. You get our personalization as an input to your own UI, so you don't have to build a ranking engine to launch a strong experience.
+
+Because you own the UI, you keep final control over how offers are presented — you can display or re-order them however you like. The personalization is additive, not a takeover.
+
+## When to choose it
+
+- You want a custom offer UI **and** AdGem's personalization.
+- You want to keep control of presentation without building ranking logic from scratch.
+- You're on any platform — Prism works wherever you can make API calls.
+
+If you'd rather build your own ranking on the raw catalog, see the [Offer API](/docs/integrate/offer-delivery/partner-built/offer-api). If you'd rather not build a UI at all, see [Pre-built](/docs/integrate/offer-delivery/pre-built).
+
+## Build with Prism
+
+See the **[Prism reference](/docs/reference/prism/overview)** for the endpoint, authentication, queries, and examples.

--- a/docs/integrate/offer-delivery/pre-built/index.md
+++ b/docs/integrate/offer-delivery/pre-built/index.md
@@ -1,12 +1,18 @@
 ---
 title: Pre-built (Fastest)
 sidebar_label: Pre-built (Fastest)
+description: AdGem provides the offerwall UI — embed it and pass a player ID. Choose the option that fits your platform.
 ---
 
 # Pre-built (Fastest)
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+With a pre-built integration, AdGem owns the offerwall UI and the offer presentation. You embed it and pass us a player ID; we handle the rest. It's the fastest path to live offers and fits most publishers.
 
-AdGem owns the UI and the offer-presentation logic. You embed and pass us a player ID.
+Choose the option that matches your platform:
+
+- **[Web Offerwall](/docs/integrate/offer-delivery/pre-built/web-offerwall)** — an embed for the web and in-app web views.
+- **[iOS SDK](/docs/integrate/offer-delivery/pre-built/ios-sdk)** — native iOS apps.
+- **[Android SDK](/docs/integrate/offer-delivery/pre-built/android-sdk)** — native Android apps.
+- **[Unity SDK](/docs/integrate/offer-delivery/pre-built/unity-sdk)** — Unity games on iOS and Android.
+
+Want to build your own offer UI instead? See **[Partner-built](/docs/integrate/offer-delivery/partner-built)**, or compare both in **[Decide your path](/docs/get-started/decide)**.

--- a/docs/integrate/overview.md
+++ b/docs/integrate/overview.md
@@ -1,12 +1,19 @@
 ---
 title: Integrate
 sidebar_label: Overview
+description: The two independent choices behind every AdGem integration — Offer Delivery and Reward Mechanism.
 ---
 
 # Integrate
 
-:::note Prototype placeholder
-Structure-only page for IA validation — see [PUB-191](https://linear.app/adaction/issue/PUB-191). Real content is a follow-on.
-:::
+Every AdGem integration is two independent choices:
 
-Every AdGem integration is two choices: how players see offers (Offer Delivery) and how conversions flow back (Reward Mechanism). They are independent — pick them separately.
+- **[Offer Delivery](/docs/integrate/offer-delivery)** — how players see and start offers. This ranges from a ready-made offerwall AdGem hosts to a fully custom experience you build on our APIs.
+- **[Reward Mechanism](/docs/integrate/reward-mechanism)** — how completed conversions flow back to you so you can reward the player. Most integrations use server postbacks.
+
+You pick them separately: any delivery method can pair with any reward mechanism.
+
+## Where to start
+
+- Not sure which delivery method fits? See **[Decide your path](/docs/get-started/decide)** — it walks through the trade-offs and points you to a guide.
+- New to the terminology first? See **[Core concepts](/docs/get-started/core-concepts)**.


### PR DESCRIPTION
Cluster B of the marketing/product narrative pages — the six **Integrate** connectors. **For marketing/product review.** Base: `main`. Pairs with cluster A (#53), reusing the same build-vs-consume framing.

## New content (thin connectors — orient + route, no restating)
- **Integrate / overview** — the two independent axes: Offer Delivery × Reward Mechanism.
- **Offer Delivery landing** — pre-built vs partner-built; routes to both + Decide your path.
- **Pre-built landing** — AdGem owns the UI; options **by platform fit** (Web Offerwall + iOS/Android/Unity SDKs).
- **Partner-built landing** — you own the UI; Prism (recommended) vs Offer API, by fit.
- **Prism narrative** — when/why Prism: personalization as an input, you keep presentation control ("additive, not a takeover"); links to the Prism reference.
- **Offer API narrative** — when/why the Offer API: raw catalog, total control / own-ranking / raw-data needs; links to the Offer API reference.

## Framing + firewall
Same as #53: presented **by fit**, not the internal push order; no gaps, roadmap, commercial strategy, or "powered by" plumbing. "Iframe" appears as the **Web Offerwall**.

## Notes
- Builds clean (no broken links). Links into Decide your path / Core concepts (cluster A, #53) resolve against the placeholders until #53 merges, then to the real pages — merge #53 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the integration overview into a clearer guide with the main integration choices and where to start.
  * Replaced placeholder pages for offer delivery with complete guidance for both pre-built and partner-built paths.
  * Added clearer explanations and navigation links to help readers choose the right setup.
  * Included more detailed docs for custom UI options and the available API-based integration approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->