### PR TITLE
docs: richer Resources index — link cards (PUB-191)

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -4,18 +4,46 @@ sidebar_label: Resources
 description: Branding assets, glossary, support, and other resources for AdGem publishers.
 ---
 
+import Link from '@docusaurus/Link';
+
 # Resources
 
 Helpful resources for AdGem publishers, including branding materials, industry terminology, support information, and more.
 
 ## Support
 
-- **[Player Support Overview](./player-support-overview.md)** --- How AdGem handles player support requests on behalf of publishers.
-- **[Player Support Links](./player-support-links.md)** --- The `support_portal` and `support_url` links the APIs return for players.
-- **[Developer Support](./developer-support.md)** --- How to get engineering help with your integration.
-- **[Service Status](https://status.adgem.com)** --- Real-time AdGem service status monitoring.
+<div className="resource-cards">
+<Link className="resource-card" to="/docs/resources/player-support-overview">
+<span className="resource-card__title">Player Support Overview</span>
+<span className="resource-card__desc">How AdGem handles player support requests on behalf of publishers.</span>
+</Link>
+<Link className="resource-card" to="/docs/resources/player-support-links">
+<span className="resource-card__title">Player Support Links</span>
+<span className="resource-card__desc">The <code>support_portal</code> and <code>support_url</code> links the APIs return for players.</span>
+</Link>
+<Link className="resource-card" to="/docs/resources/developer-support">
+<span className="resource-card__title">Developer Support</span>
+<span className="resource-card__desc">How to get engineering help with your integration.</span>
+</Link>
+<Link className="resource-card" to="https://status.adgem.com">
+<span className="resource-card__title">Service Status</span>
+<span className="resource-card__desc">Real-time AdGem service status monitoring.</span>
+</Link>
+</div>
 
 ## Reference
 
-- **[Branding Assets](./branding-assets.mdx)** --- Official AdGem logos and media assets for your integration.
-- **[Glossary](./glossary.md)** --- Definitions for 75+ advertising and mobile industry terms.
+<div className="resource-cards">
+<Link className="resource-card" to="/docs/resources/branding-assets">
+<span className="resource-card__title">Branding Assets</span>
+<span className="resource-card__desc">Official AdGem logos and media assets for your integration.</span>
+</Link>
+<Link className="resource-card" to="/docs/resources/glossary">
+<span className="resource-card__title">Glossary</span>
+<span className="resource-card__desc">Definitions for 75+ advertising and mobile industry terms.</span>
+</Link>
+<Link className="resource-card" to="/docs/resources/changelog">
+<span className="resource-card__title">Changelog</span>
+<span className="resource-card__desc">Release notes for each AdGem integration.</span>
+</Link>
+</div>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -543,3 +543,54 @@ button,
   color: var(--ifm-color-emphasis-700);
   line-height: 1.4;
 }
+
+/* ============================================
+   Resources index — link cards
+   Whole-card links in a responsive grid (flex-wrap,
+   no media queries). Selectors include `.markdown a`
+   so they win over the global content-link styling.
+   ============================================ */
+
+.resource-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0 2rem;
+}
+
+.markdown a.resource-card,
+.resource-card {
+  flex: 1 1 260px;
+  display: flex;
+  flex-direction: column;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-top: 3px solid var(--adgem-secondary-purple);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+  font-family: var(--ifm-font-family-base);
+  font-weight: 400;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.markdown a.resource-card:hover {
+  border-color: var(--adgem-secondary-purple);
+  box-shadow: 0 4px 14px rgba(21, 1, 88, 0.12);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.resource-card__title {
+  margin-bottom: 0.3rem;
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ifm-heading-color);
+}
+
+.resource-card__desc {
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--ifm-color-emphasis-700);
+}


### PR DESCRIPTION
Reworks the **Resources** index from a bulleted list (with literal `---` separators that rendered as triple-hyphens) into a responsive card grid. Base: `main`.

## What changed
- Each **Support** and **Reference** item is now a **whole-card link** — title + description — instead of a bullet with a ` --- ` separator. The literal triple-hyphens are gone.
- **Responsive:** cards use `flex-wrap` with `flex: 1 1 260px` (no media queries), so they sit several across on wide viewports and stack on narrow ones — same pattern as the Decide-your-path spectrum.
- **On-brand:** purple top-accent, hover lift + shadow, surface background; dark-mode aware via Infima/AdGem tokens. Styles scoped under `.resource-cards` in `custom.css` (selectors include `.markdown a` so they win over global content-link styling).
- **Added a Changelog card** — the index didn't link the Changelog before.

## Notes
- Builds clean (no broken links). `resources/index.md` now imports `@docusaurus/Link` for SPA navigation on the cards.
- Pure presentation change to one index page; no content moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)