### PR TITLE
docs: document the client-side Prism token flow (PUB-191)

### DIFF
--- a/docs/configure/security.md
+++ b/docs/configure/security.md
@@ -15,10 +15,10 @@ Protect your AdGem integration on three fronts: keep your **credentials** safe, 
 | Prism | JWT access token (exchanged from a refresh token) | [Prism › Authentication](/docs/reference/prism/authentication) |
 | Reporting API | Dashboard-generated bearer token | [Reporting API › Authentication](/docs/reference/reporting-api/authentication) |
 
-Treat refresh tokens, access tokens, and your postback/webhook secret as secrets:
+Keep your **refresh token** and your **postback/webhook secret** server-side — never ship them in client apps or commit them to source control. Then:
 
-- Store them server-side; never ship them in client apps or commit them to source control.
-- Exchange refresh tokens for short-lived access tokens on your server, and hand clients only short-lived tokens when unavoidable.
+- Exchange the refresh token for a **short-lived access token on your server**.
+- For **client-side offer delivery** (such as Prism), pass that short-lived access token to your client to request offers — this is expected, since offers are tailored to the end user's device and location. Only the access token reaches the client; the refresh token and the exchange stay on your server.
 - Always call AdGem over HTTPS.
 
 ## Verify incoming postbacks

--- a/docs/reference/prism/authentication.md
+++ b/docs/reference/prism/authentication.md
@@ -14,6 +14,10 @@ The authentication process involves two phases:
 1. **Account Setup (performed by AdGem Team):** The AdGem Team registers and confirms your user account, then provides you with a `refresh_token` (a long-lived token).
 2. **Token Acquisition (performed by you):** You exchange the `refresh_token` for a short-lived JWT `access_token`, which you include in the `Authorization` header of all API requests.
 
+:::note Client-side integrations
+Run the token exchange on your **server** and pass the resulting **short-lived `access_token`** to your client to make offer requests. Keep the `refresh_token` server-side — never ship it in client code. See [Security](/docs/configure/security) for the full credential-handling guidance.
+:::
+
 ### Prerequisites
 
 Before you can authenticate, the AdGem Team must complete the following internal steps for your account:


### PR DESCRIPTION
Corrects the credential guidance now that we know **client-side is the expected Prism integration pattern** (offers tailored to the end user's device + location). Base: `main`.

## What changed
- **Configure › Security** — the credentials guidance said to keep *all* tokens server-side and give clients short-lived tokens "only when unavoidable." That's wrong for Prism. Reworded to: keep the **refresh token** + the token **exchange** server-side, and pass the **short-lived access token** to your client to request offers (only the access token reaches the client).
- **Reference › Prism › Authentication** — added a "Client-side integrations" note describing the same flow, linking to Security.

## Deliberately *not* included
No "call Prism directly from a browser/webview" transport instructions — that path is currently **CORS-blocked** (the API Gateway rejects the preflight, **PUB-429**). This PR only corrects the **token-handling model**, which is accurate today (native clients work; the model is unchanged). We add the client-side call guidance once PUB-429 lands.

## Context
- Prism integration model + constraints: PUB-429 (CORS, High) and PUB-430 (app-attestation for serverless clients).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified credential handling guidance to distinguish server-side secrets from short-lived access tokens.
  * Added a clearer flow for exchanging tokens on the server before optionally passing a short-lived access token to the client.
  * Expanded authentication docs with a client-side integration note and a link to the security guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->